### PR TITLE
issue-1 fix

### DIFF
--- a/bin/app.js
+++ b/bin/app.js
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
-const fs = require(`fs`);
 const yargs = require(`yargs`);
-const ff = require(`./fileFunctions`);
-const pathModule = require(`path`);
+const package = require(`../package.json`);
 
 const options = yargs
   .usage(`Usage: -i <path>`)
@@ -19,7 +17,7 @@ const options = yargs
   })
   .help("h")
   .alias("h", "help")
-  .version()
+  .version(`octo ${package.version}`)
   .alias(`v`, `version`).argv;
 
 addDirectory(options.output ? options.output : `./dist`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "octo 0.0.1",
+  "version": "0.0.1",
   "description": "A tool that allows you to generate static sites based off of text data.",
   "main": "bin/app.js",
   "bin": {


### PR DESCRIPTION
Usage: Fixes #1 

## Problem
Could not install tool with <code>npm -i</code> because version in package.json had a string in it. 

## Fix 
Rewrite the code with yargs so when user requests version, the string is implemented in the code and not the package.json

