### PR TITLE
Refactor ./bin/app.js and adding test

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
   "env": {
     "browser": false,
     "node": true,
-    "es2021": true
+    "es2021": true,
+    "jest": true
   },
   "extends": "eslint:recommended",
   "parserOptions": {

--- a/bin/app.js
+++ b/bin/app.js
@@ -1,37 +1,11 @@
-#!/usr/bin/env node
-const yargs = require(`yargs`);
-const config = require(`../package.json`);
-
 //Import fileFunctions
 const fileFunctions = require("./fileFunctions");
-const options = yargs
-  .usage(`Usage: -i <path>`)
-  .option(`input`, {
-    alias: `i`,
-    describe: `Path to file`,
-    type: `string`,
-    demandOption: true,
-  })
-  .option(`output`, {
-    alias: `o`,
-    describe: `Output directory for html parsed files`,
-    type: `string`,
-  })
-  .option(`lang`, {
-    alias: `l`,
-    describe: `Language attribute in HTML file`,
-    type: `string`,
-  })
-  .help("h")
-  .alias("h", "help")
-  .version(`octo ${config.version}`)
-  .alias(`v`, `version`).argv;
+const options = require("./options");
 
-//Using fileFuntions methods
-fileFunctions.addDirectory(options.output ? options.output : `./dist`);
+fileFunctions.addDirectory(options().output ? options().output : `./dist`);
 
 fileFunctions.main(
-  `${options.input}`,
-  `${options.output ? options.output : `./dist`}`,
-  `${options.lang ? options.lang : `en-CA`}`
+  `${options().input}`,
+  `${options().output ? options().output : `./dist`}`,
+  `${options().lang ? options().lang : `en_CA`}`
 );

--- a/bin/options.js
+++ b/bin/options.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+const yargs = require(`yargs`);
+const config = require(`../package.json`);
+
+const options = (args = process.argv.slice(2)) =>
+  yargs(args)
+    .usage(`Usage: -i <path>`)
+    .option(`input`, {
+      alias: `i`,
+      describe: `Path to file`,
+      type: `string`,
+      demandOption: true,
+    })
+    .option(`output`, {
+      alias: `o`,
+      describe: `Output directory for html parsed files`,
+      type: `string`,
+      default: `./dist`,
+    })
+    .option(`lang`, {
+      alias: `l`,
+      describe: `Language attribute in HTML file`,
+      type: `string`,
+      default: `en_CA`,
+    })
+    .help("h")
+    .alias("h", "help")
+    .version(`octo ${config.version}`)
+    .alias(`v`, `version`).argv;
+//Using fileFuntions methods
+
+module.exports = options;

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,0 +1,30 @@
+const  options = require('../bin/options'); 
+
+const parsedArgs = (args) => {
+  const argvs = options(args);
+  return{
+      input: argvs.input,
+      output: argvs.output, 
+      lang: argvs.lang
+  };
+};
+
+describe("testing parsing arguments", () => {
+  const defaultOptions = {
+    input: 'path',
+    output: './dist',
+    lang: 'en_CA'
+  }
+
+  test ('passing single arguement', () => {
+    expect(parsedArgs(['-i','path'])).toEqual(defaultOptions);
+  })
+
+  test('full arguement options', () => {
+    expect(parsedArgs(['-i','path', '-o', 'dist', '--lang','en_CA'])).toEqual({
+      input: 'path',
+      output: 'dist',
+      lang: 'en_CA'
+    });
+  });
+});


### PR DESCRIPTION
Fix #16 

When create test case for `./bin/app.js` . I have made `options` to become a callable function, but when I try to test it the `fileFunction` object which also access `options` function create these errors:

```bash
●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "This is main Error
    Error: ENOENT: no such file or directory, lstat 'C:\Users\Administrator\Desktop\repo\octo\undefined'".

      121 |       if (path.includes(".txt")) {
      122 |         return textToHTML(path, lang).then((data) => {
      126 |

      at console.log (node_modules/@jest/console/build/BufferedConsole.js:199:10)
      at bin/fileFunctions.js:123:29
```

To solve it, I decide to split `bin/app.js` to become `bin/options.js` and `test/app.test.js` . Please kindly review it